### PR TITLE
Adds Arch-flavored install script; Fixes some spelling and grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,26 @@
 
 Easily install ALL of Google's Web Fonts using the following command in your terminal.
 
-####Mac Users:
+### Mac users:
 
 		curl https://raw.githubusercontent.com/qrpike/Web-Font-Load/master/install.sh | sh
 
-####Debian Users:
+### Linux
+
+####Debian users:
 
 		curl https://raw.githubusercontent.com/qrpike/Web-Font-Load/master/install_debian.sh | sh
 
-The debian install script should work for most linux distros.
+####Arch Linux users:
+
+    curl https://raw.githubusercontent.com/qrpike/Web-Font-Load/master/install_arch.sh | sh
+
+The Debian install script should work for most Linux distros. Arch requires a special installation
+due to differences in the folder structure. You can compare the scripts to take a look at this.
 
 ### Updating:
 
-For updating fonts, just re-run this script. It will overwrite duplicates.
+To update the fonts, just re-run this script. It will overwrite duplicates.
 
 You may need to restart for Font Book to pick up the new fonts.
 

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
+# For OS X-based systems.
 
 clear
-echo "Installing All Google Web Fonts onto your Mac"
-echo "Downloading The Fonts..."
+echo "Installing all Google Web Fonts onto your Mac"
+echo "Downloading the fonts..."
 cd ~/Documents/
 curl -L https://github.com/w0ng/googlefontdirectory/tarball/master -o master.tar.gz
 echo "Extracting the fonts..."
@@ -18,8 +19,8 @@ rm *.json
 cd ..
 mv fonts/* /Library/Fonts/
 
-echo "Fonts Installed, Cleaning Up Files.."
+echo "Fonts installed; Cleaning up files..."
 cd ~/Documents/
 rm -f master.tar.gz
 rm -rf goog-fonts
-echo "All Done! All Google Fonts installed."
+echo "All done! All Google Fonts installed."

--- a/install_arch.sh
+++ b/install_arch.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-# For Debian-based systems.
+# For Arch-based Linux systems.
 
 clear
-echo "Installing all Google Web Fonts onto your Debian system"
+echo "Installing all Google Web Fonts onto your Arch system"
 echo "Downloading the fonts..."
 cd ~/Documents/
 curl -L https://github.com/w0ng/googlefontdirectory/tarball/master -o master.tar.gz
@@ -15,9 +15,9 @@ rm -R -- */
 rm *.txt
 rm *.json
 cd ..
-sudo mv fonts/* /usr/local/share/fonts/
+sudo mv fonts/* /usr/share/fonts/
 
-echo "Fonts installed, cleaning up files.."
+echo "Fonts installed; Cleaning up files..."
 cd ~/Documents/
 rm -f master.tar.gz
 rm -rf goog-fonts


### PR DESCRIPTION
This pull request adds an Arch variant of the install script, since the Arch folder structures differs a bit from the regular Debian one. Also I addressed some capitalization and grammar errors, because I'm weird like that. :smile: 
