### PR TITLE
Make this script work, remove README

### DIFF
--- a/install_debian.sh
+++ b/install_debian.sh
@@ -14,8 +14,9 @@ find . -mindepth 2 -type f -print -exec mv {} . \;
 rm -R -- */
 rm *.txt
 rm *.json
+rm *.md
 cd ..
-sudo mv fonts/* /usr/local/share/fonts/
+sudo mv goog-fonts/* /usr/local/share/fonts/
 
 echo "Fonts installed, cleaning up files.."
 cd ~/Documents/


### PR DESCRIPTION
The script purports to move fonts from a "fonts" folder, when the script actually creates a folder "goog-fonts". This fixes this, and also removes the README.md file present in the archive.
