### PR TITLE
Add command to update the font cache after installing

### DIFF
--- a/install_debian.sh
+++ b/install_debian.sh
@@ -29,5 +29,8 @@ echo "Fonts installed, cleaning up files.."
 cd ~/Documents/
 rm -f master.tar.gz
 rm -rf goog-fonts
-echo "All done! All Google Fonts installed."
 
+echo "Updating font cache..."
+fc-cache -f
+
+echo "All done! All Google Fonts installed."


### PR DESCRIPTION
Before the fonts can be used the font cache needs to be updated. This can be done with a simple command.
